### PR TITLE
#addid method of the queue not sending properly

### DIFF
--- a/lib/ruby-mpd/plugins/queue.rb
+++ b/lib/ruby-mpd/plugins/queue.rb
@@ -26,7 +26,7 @@ class MPD
       # Optionally, one can specify the position on which to add the song (since MPD 0.14).
       # @return [Integer] id of the song that was added.
       def addid(path, pos=nil)
-        send_command :addid, pos
+        send_command :addid, path, pos
       end
 
       # Clears the current queue.


### PR DESCRIPTION
I think #addid is missing an argument. The current source drops the `path` argument, which is throwing `MPD::NotFound: [addid] No such song`:

``` ruby
def addid(path, pos=nil)
  send_command :addid, pos
end
```

I stuck `path` into that command, and it seems to be working as expected :)
