### PR TITLE
Fixes for playlist handling

### DIFF
--- a/lib/ruby-mpd/playlist.rb
+++ b/lib/ruby-mpd/playlist.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 class MPD
   # An object representing an .m3u playlist stored by MPD.
   #
@@ -22,7 +24,14 @@ class MPD
     # Lists the songs in the playlist. Playlist plugins are supported.
     # @return [Array<MPD::Song>] songs in the playlist.
     def songs
-      @mpd.send_command(:listplaylistinfo, @name).map {|hash| Song.new(hash) }
+      if @mpd.send_command(:listplaylistinfo, @name).to_s =~ URI::regexp
+        @mpd.send_command(:listplaylistinfo, @name).map {|hash| Song.new({:file=>hash, :time=>0}) }
+      else
+        @mpd.send_command(:listplaylistinfo, @name).map {|hash| Song.new(hash) }
+      end
+    rescue TypeError
+      p "Files in Playlist '#{@name}' do not exist"
+      return nil
     rescue NotFound
       return [] # we rescue in the case the playlist doesn't exist.
     end


### PR DESCRIPTION
After  mucking around for a while in parser.rb  i could not find a clean way to handle this, so the easiest way seemed to be directly in playlists.rb. This commit fixes #4 
- raise Error when playlist contains erroneos songs
- handle http stream in playlist
- require uri
