### PR TITLE
Fix song callback when song number does not change

### DIFF
--- a/lib/ruby-mpd.rb
+++ b/lib/ruby-mpd.rb
@@ -105,14 +105,12 @@ class MPD
         status[:time] = [nil, nil] if !status[:time] # elapsed, total
         status[:audio] = [nil, nil, nil] if !status[:audio] # samp, bits, chans
 
+        status[:song] = mpd.current_song
+
         status.each do |key, val|
           next if val == old_status[key] # skip unchanged keys
-
-          if key == :song
-            emit(:song, mpd.current_song)
-          else # convert arrays to splat arguments
-            val.is_a?(Array) ? emit(key, *val) : emit(key, val)
-          end
+          # convert arrays to splat arguments
+          val.is_a?(Array) ? emit(key, *val) : emit(key, val)
         end
 
         old_status = status

--- a/lib/ruby-mpd/song.rb
+++ b/lib/ruby-mpd/song.rb
@@ -20,7 +20,7 @@ class MPD::Song
 
   # Two songs are the same when they are the same file.
   def ==(another)
-    self.file == another.file
+    self.class == another.class && self.file == another.file
   end
 
   # @return [String] A formatted representation of the song length ("1:02")


### PR DESCRIPTION
Currently, the MPD callback mechanism seems to be missing some song updates because of the way it compares against the last version of the status hash. The `:song` key stores an integer corresponding to the song number in the playlist. As far as I know (and please correct me if I'm wrong), this integer can remain constant even though the current song changed. E.g. when you are playing single songs from the library and the playlist is cleared before adding every new song, keeping `status[:song] == 0`.

This patch overrides the `:song` key in the status hash with the current song, performing an additional request to the MPD daemon, but thus making sure that we have correct information before entering the update loop. The `MPD::Song#==` method was also updated so that songs can be compared against nil.
