### PR TITLE
Add rake console task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,16 @@
 require 'rake/testtask'
+
 Rake::TestTask.new(:test) do |test|
   test.verbose = true
+end
+
+desc "Open an irb session preloaded with this API"
+task :console do
+  $:.unshift(File.expand_path('../lib', __FILE__))
+  require 'ruby-mpd'
+  require 'irb'
+  ARGV.clear
+  IRB.start
 end
 
 task :default => :test


### PR DESCRIPTION
This allows to invoke the `console` task which preloads the module and launches an IRB shell.
