### PR TITLE
Expose some more attributes so they can be queried from elsewhere

### DIFF
--- a/lib/ruby-mpd.rb
+++ b/lib/ruby-mpd.rb
@@ -39,8 +39,7 @@ class MPD
   include Plugins::Reflection
   include Plugins::Channels
 
-  # The version of the MPD protocol the server is using.
-  attr_reader :version
+  attr_reader :version, :hostname, :port
 
   # Initialize an MPD object with the specified hostname and port.
   # When called without arguments, 'localhost' and 6600 are used.


### PR DESCRIPTION
Accessing them like mpd.hostname just quite natural, so expose them accordingly.
