### PR TITLE
removed unused var and lack of parens to get rid of warning

### DIFF
--- a/lib/ruby-mpd.rb
+++ b/lib/ruby-mpd.rb
@@ -93,7 +93,7 @@ class MPD
   # @return [void]
   def emit(event, *args)
     return unless @callbacks[event]
-    @callbacks[event].each { |handle| handle.call *args }
+    @callbacks[event].each { |handle| handle.call(*args) }
   end
 
   # Constructs a callback loop thread and/or resumes it.

--- a/lib/ruby-mpd/parser.rb
+++ b/lib/ruby-mpd/parser.rb
@@ -121,7 +121,7 @@ class MPD
     # @return [Array<String>]
     def make_chunks(string)
       first_key = string.match(/\A(.+?):\s?/)[1]
-      chunks = string.split(/\n(?=#{first_key})/).map(&:strip)
+      string.split(/\n(?=#{first_key})/).map(&:strip)
     end
 
     # Parses the response, determining per-command on what parsing logic


### PR DESCRIPTION
When loading the gem with `$VERBOSE = true` some errors are thrown:

```
 pry(main)> require 'ruby-mpd'
/home/michael/.rvm/gems/ruby-2.0.0-p353/gems/ruby-mpd-0.3.1/lib/ruby-mpd.rb:98: warning: `*' interpreted as argument prefix
/home/michael/.rvm/gems/ruby-2.0.0-p353/gems/ruby-mpd-0.3.1/lib/ruby-mpd/parser.rb:124: warning: assigned but unused variable - chunks
```

This PR makes minor changes to that these warnings aren't triggered.

http://devblog.avdi.org/2011/06/23/how-ruby-helps-you-fix-your-broken-code/
