### PR TITLE
Adding Travis CI integration to the repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: ruby
+before_install:
+  - gem install bundler

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ruby-mpd
 
+[![Build Status](https://travis-ci.org/archSeer/ruby-mpd.svg?branch=master)](https://travis-ci.org/archSeer/ruby-mpd)
+
 ruby-mpd is a powerful object-oriented client for the  [Music Player Daemon](http://www.musicpd.org), forked from librmpd. librmpd is as of writing outdated by 6 years! This library tries to act as a successor, originally using librmpd as a base, however almost all of the codebase was rewritten. ruby-mpd supports all "modern" MPD features as well as callbacks.
 
 ## MPD Protocol
@@ -45,7 +47,7 @@ mpd.disconnect
 Once connected, you can issue commands to talk to the server.
 
 ```ruby
-mpd.connect    
+mpd.connect
 mpd.play if mpd.stopped?
 song = mpd.current_song
 puts "Current Song: #{song.artist} - #{song.title}"
@@ -178,7 +180,7 @@ end
 ```
 
 One can also use separate methods or Procs and whatnot, just pass them in as a parameter.
-  
+
 ```ruby
 # Using a Proc
 proc = Proc.new { |volume| puts “Volume was set to #{volume}.” }
@@ -218,7 +220,7 @@ ruby-mpd supports callbacks for any of the keys returned by `MPD#status`, as wel
 * *error*: if there is an error, returns message here
 
 * *connection*: Are we connected to the daemon? true or false
- 
+
 Note that if the callback returns more than one value, the callback needs more arguments in order to recieve those values:
 
 ```ruby

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,12 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end
+
 desc "Open an irb session preloaded with this API"
 task :console do
   require 'ruby-mpd'
@@ -13,4 +19,4 @@ task :console do
   IRB.start
 end
 
-task :default => :test
+task :default => [:test, :spec]


### PR DESCRIPTION
This PR introduces continuous integration with Travis CI.

Note that @archSeer you're going to have to explicitly enable the builds in the Travis CI configuration to start running tests on changes. (Also, tests won't trigger automatically just now, Travis will start running tests at the first new commit after the repository has been enabled)

### RSpec as a default Rake task

It adds the `:spec` rake task into the list of defaults, which means not only the Test::Unit tests will run upon `rake` but RSpec tests as well. This allows us to use a simple `rake` when building the project and run all tasks that are (or will become) necessary.

### Configured Travis CI environment

This change also adds a `.travis.yml` configuration file that instructs Travis how to run the build. The extra (and admittedly obscure) `before_install` script is necessary because currently the `Gemfile.lock` locked down the version of bundler that is newer than what currently Travis CI has installed. This addresses the __This Gemfile requires a different version of Bundler.__ error. See an example [here](https://travis-ci.org/liquid/ruby-mpd/builds/66353718).

Additionally we add a badge to the README to better communicate the current status of the repository in case someone wants to use HEAD versions or wants to communicate.

### A note on current failures

Note that Travis CI will currently fail as there isn't a running version of the MPD server during the build. This is related to the [issues described](https://github.com/archSeer/ruby-mpd#tests) in the README. I think we should have a discussion on how we are going to proceed and how to address this issue.