### PR TITLE
WIP: Introduce hashie to simplify object wrappers.

### DIFF
--- a/lib/ruby-mpd/song.rb
+++ b/lib/ruby-mpd/song.rb
@@ -1,22 +1,16 @@
+require 'hashie/mash'
+
 class MPD; end
 
 # Object representation of a song.
 #
 # If the field doesn't exist or isn't set, nil will be returned
-class MPD::Song
-  # length in seconds
-  attr_reader :file, :title, :time, :artist, :album, :albumartist
+class MPD::Song < Hashie::Mash
 
-  def initialize(mpd, options)
+  # allowed fields are @types + :file
+  def initialize(mpd, data)
     @mpd = mpd
-    @data = {} # allowed fields are @types + :file
-    @time = options.delete(:time) # an array of 2 items where last is time
-    @file = options.delete(:file)
-    @title = options.delete(:title)
-    @artist = options.delete(:artist)
-    @album = options.delete(:album)
-    @albumartist = options.delete(:albumartist)
-    @data.merge! options
+    super data
   end
 
   # Two songs are the same when they are the same file.
@@ -25,11 +19,11 @@ class MPD::Song
   end
 
   def elapsed
-    @time.first
+    time.first
   end
 
   def track_length
-    @time.last
+    time.last
   end
 
   # @return [String] A formatted representation of the song length ("1:02")
@@ -43,18 +37,6 @@ class MPD::Song
   # @return [Hash] Key value pairs from "comments" metadata on a file.
   # @return [Boolean] True if comments are empty
   def comments
-    @comments ||= @mpd.send_command :readcomments, @file
-  end
-
-  # Pass any unknown calls over to the data hash.
-  def method_missing(m, *a)
-    key = m #.to_s
-    if key =~ /=$/
-      @data[$`] = a[0]
-    elsif a.empty?
-      @data[key]
-    else
-      raise NoMethodError, "#{m}"
-    end
+    @comments ||= @mpd.send_command :readcomments, file
   end
 end

--- a/ruby-mpd.gemspec
+++ b/ruby-mpd.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "hashie", "~> 3.4.2"
+
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.5"


### PR DESCRIPTION
Still messing around with this, I was never satisfied with how the original was implemented, but I didn't want to introduce another dependency back then.

The ideal way probably is to use `Hashie::Dash` and specify the allowed keys, probably do so dynamically (allowed keys are `mpd.types` and `:file`).