### PR TITLE
Change behavior of == to operate on song hashes

### DIFF
--- a/lib/ruby-mpd/song.rb
+++ b/lib/ruby-mpd/song.rb
@@ -19,9 +19,9 @@ class MPD::Song
     @data.merge! options
   end
 
-  # Two songs are the same when they are the same file.
+  # Two songs are the same when they share the same hash.
   def ==(another)
-    self.class == another.class && self.file == another.file
+    to_h == another.to_h
   end
 
   def to_h
@@ -68,4 +68,6 @@ class MPD::Song
       raise NoMethodError, "#{m}"
     end
   end
+
+  alias :eql? :==
 end


### PR DESCRIPTION
for callbacks. From the issue thread:

I did some digging and I think I found a rather smooth solution to this issue! The thing is, the MPD song details change when the radio track changes but comparing the songs with == returns true - even though the object has changed! Consider this:

```
head :029 > test
 => #<MPD::Song:0x000000016c9750 @data={:name=>"RPGN Radio", :pos=>0, :id=>51}, @time=nil, @file="http://stream.rpgamers.net:8000/rpgn", @title="Infinite Undiscovery - Pure Alabaster", @artist=nil, @album=nil, @albumartist=nil>
head :030 > test2
 => #<MPD::Song:0x0000000168e1c8 @data={:name=>"RPGN Radio", :pos=>0, :id=>51}, @time=nil, @file="http://stream.rpgamers.net:8000/rpgn", @title="Okami - Shinshuu Plains I & II", @artist=nil, @album=nil, @albumartist=nil>
head :033 > test === test2
 => true 
head :034 > test == test2
 => true 
head :035 > test.eql? test2
 => false 
head :036 > test.equal? test2
 => false 
```

So, if we used .eql? or .equal? (I am not exactly sure which one is better) instead of == at https://github.com/archSeer/ruby-mpd/blob/master/lib/ruby-mpd.rb#L228 then the MPD song callback would trigger when the track in a stream changes. I think this change makes a lot of sense. My only concern is that it might cause unexpected behavior with other callbacks (although I doubt it) but we should test and make sure everything still works as expected.

Also, I checked the refactored version in #32 and it seems that it would need to be changed in the same way.

Thanks, let me know what you think!