### PR TITLE
Added new current_song implementation that merges info from status

### DIFF
--- a/lib/ruby-mpd/plugins/information.rb
+++ b/lib/ruby-mpd/plugins/information.rb
@@ -21,6 +21,19 @@ class MPD
         hash.is_a?(TrueClass) ? nil : Song.new(self, hash)
       end
 
+      # Calls both currentsong and status in order to get complete song information
+      #
+      # @return [MPD::Song]
+      # @return [nil] if there is no song playing
+      def current
+        hash = send_command :currentsong
+        # if there is no current song
+        return nil if hash == true
+        # currentsong leaves out time, so we get it from status
+        hash[:time] = status[:time]
+        Song.new(self, hash)
+      end
+
       # Waits until there is a noteworthy change in one or more of MPD's subsystems.
       # As soon as there is one, it lists all changed systems in a line in the format
       # 'changed: SUBSYSTEM', where SUBSYSTEM is one of the following:

--- a/spec/ruby-mpd/plugins/information_spec.rb
+++ b/spec/ruby-mpd/plugins/information_spec.rb
@@ -30,6 +30,26 @@ RSpec.describe MPD::Plugins::Information do
     end
   end
 
+  describe "#current" do
+    context "when there is no currentsong" do
+      it "should make the correct call" do
+        expect(subject).to receive(:send_command).with(:currentsong).and_return(true)
+        expect(subject.current).to be_nil
+      end
+    end
+
+    context "when there is a currentsong" do
+      let(:song) { double('song') }
+
+      it "should make the correct calls" do
+        expect(MPD::Song).to receive(:new).with(subject, {:time => nil}).and_return(song)
+        expect(subject).to receive(:send_command).with(:currentsong).and_return({})
+        expect(subject).to receive(:status).and_return({})
+        expect(subject.current).to eql(song)
+      end
+    end
+  end
+
   describe "#status" do
     it "should make the correct call" do
       expect(subject).to receive(:send_command).with(:status)


### PR DESCRIPTION
Looking for input on this. I didn't want to have the current_song method call two commands as it was because that didn't seem like it fit the pattern of the rest of the code (with each method mapping to one command.) As a compromise I renamed that method that only calls currentsong to currentsong which only returns a hash and created a new current_song that returns a song object as expected (so as not to break compatibility.) I definitely don't know if this is a good solution so let me know what you guys think.