### PR TITLE
removed deprecated method to suppress warning

### DIFF
--- a/lib/ruby-mpd.rb
+++ b/lib/ruby-mpd.rb
@@ -270,7 +270,7 @@ private
   end
 
   def socket
-    @socket ||= File.exists?(@hostname) ? UNIXSocket.new(@hostname) : TCPSocket.new(@hostname, @port)
+    @socket ||= File.exist?(@hostname) ? UNIXSocket.new(@hostname) : TCPSocket.new(@hostname, @port)
   end
 
   SERVER_ERRORS = {


### PR DESCRIPTION
File.exists? is deprecated in favor of File.exist?