### PR TITLE
Guard track_length against nil @time

### DIFF
--- a/lib/ruby-mpd/song.rb
+++ b/lib/ruby-mpd/song.rb
@@ -239,7 +239,7 @@ class MPD::Song
   end
 
   def track_length
-    @time.last
+    @time && @time.last
   end
 
   # @return [String] A formatted representation of the song length ("1:02")


### PR DESCRIPTION
Fixes #68 by passing the `nil` on through the method call.