### PR TITLE
fixed broken reconnect on timeout

### DIFF
--- a/lib/ruby-mpd.rb
+++ b/lib/ruby-mpd.rb
@@ -193,7 +193,7 @@ class MPD
         socket.puts convert_command(command, *args)
         response = handle_server_response
         return parse_response(command, response)
-      rescue Errno::EPIPE
+      rescue Errno::EPIPE, ConnectionError
         reconnect
         retry
       end
@@ -254,11 +254,13 @@ private
     msg = ''
     while true
       case line = socket.gets
-      when "OK\n", nil
+      when "OK\n"
         break
       when /^ACK/
         error = line
         break
+      when nil
+        raise ConnectionError, 'Connection closed'
       else
         msg << line
       end


### PR DESCRIPTION
In case MPD closes a client connection due to a timeout, `#gets` returns nil which wasn't handled properly. As a result most functions will simply return true or raise exceptions in case of a timeout.