### PR TITLE
Fix playlist names that start with a number

### DIFF
--- a/lib/ruby-mpd/parser.rb
+++ b/lib/ruby-mpd/parser.rb
@@ -71,9 +71,7 @@ class MPD
         value != '0'
       elsif SYM_KEYS.include? key
         value.to_sym
-      elsif key == :playlist && !value.to_i.zero?
-        # doc states it's an unsigned int, meaning if we get 0,
-        # then it's a name string.
+      elsif key == :playlist && command != :listplaylists
         value.to_i
       elsif key == :db_update
         Time.at(value.to_i)

--- a/spec/ruby-mpd/parser_spec.rb
+++ b/spec/ruby-mpd/parser_spec.rb
@@ -69,58 +69,58 @@ RSpec.describe MPD::Parser do
   describe "#parse_key" do
     context "with valid INT_KEYS" do
       MPD::Parser::INT_KEYS.each do |key|
-        it { expect(subject.send(:parse_key, key, '32')).to eql(32) }
+        it { expect(subject.send(:parse_key, :status, key, '32')).to eql(32) }
       end
     end
 
     context "with valid SYM_KEYS" do
       MPD::Parser::SYM_KEYS.each do |key|
-        it { expect(subject.send(:parse_key, key, 'value')).to eql(:value) }
+        it { expect(subject.send(:parse_key, :status, key, 'value')).to eql(:value) }
       end
     end
 
     context "with valid FLOAT_KEYS" do
       MPD::Parser::FLOAT_KEYS.each do |key|
-        it { expect(subject.send(:parse_key, key, 10)).to eql(10.0) }
-        it { expect(subject.send(:parse_key, key, 'nan')).to be(Float::NAN) }
+        it { expect(subject.send(:parse_key, :status, key, 10)).to eql(10.0) }
+        it { expect(subject.send(:parse_key, :status, key, 'nan')).to be(Float::NAN) }
       end
     end
 
     context "with valid BOOL_KEYS" do
       MPD::Parser::BOOL_KEYS.each do |key|
-        it { expect(subject.send(:parse_key, key, '1')).to be_truthy }
-        it { expect(subject.send(:parse_key, key, '0')).to be_falsey }
+        it { expect(subject.send(:parse_key, :status, key, '1')).to be_truthy }
+        it { expect(subject.send(:parse_key, :status, key, '0')).to be_falsey }
       end
     end
 
     context "with :playlist key" do
-      it { expect(subject.send(:parse_key, :playlist, '32')).to eql(32) }
-      it { expect(subject.send(:parse_key, :playlist, '0')).to eql('0') }
+      it { expect(subject.send(:parse_key, :status, :playlist, '32')).to eql(32) }
+      it { expect(subject.send(:parse_key, :status, :playlist, '0')).to eql('0') }
     end
 
     context "with :db_update key" do
       expected_time = Time.at(1434024873)
-      it { expect(subject.send(:parse_key, :db_update, '1434024873').utc)
+      it { expect(subject.send(:parse_key, :status, :db_update, '1434024873').utc)
         .to eql(expected_time.utc) }
     end
 
     context "with :'last-modified' key" do
       let(:time) { Time.parse("Thu Nov 29 14:33:20 GMT 2001") }
-      it { expect(subject.send(:parse_key, :"last-modified", time.utc.iso8601))
+      it { expect(subject.send(:parse_key, :status, :"last-modified", time.utc.iso8601))
         .to eql(time) }
     end
 
     context "with :time, :audio key" do
-      it { expect(subject.send(:parse_key, :time, '123')).to eql([nil, 123]) }
-      it { expect(subject.send(:parse_key, :time, '99:123')).to eql([99, 123]) }
-      it { expect(subject.send(:parse_key, :audio, '12:33')).to eql([12, 33]) }
+      it { expect(subject.send(:parse_key, :status, :time, '123')).to eql([nil, 123]) }
+      it { expect(subject.send(:parse_key, :status, :time, '99:123')).to eql([99, 123]) }
+      it { expect(subject.send(:parse_key, :status, :audio, '12:33')).to eql([12, 33]) }
     end
   end
 
   describe "#parse_line" do
     context "with a valid response line" do
       let(:response) { "UPTIME:32\n xxxx" }
-      it { expect(subject.send(:parse_line, response)).to eql([:uptime, 32]) }
+      it { expect(subject.send(:parse_line, :stats, response)).to eql([:uptime, 32]) }
     end
   end
 

--- a/spec/ruby-mpd/parser_spec.rb
+++ b/spec/ruby-mpd/parser_spec.rb
@@ -95,7 +95,12 @@ RSpec.describe MPD::Parser do
 
     context "with :playlist key" do
       it { expect(subject.send(:parse_key, :status, :playlist, '32')).to eql(32) }
-      it { expect(subject.send(:parse_key, :status, :playlist, '0')).to eql('0') }
+      it { expect(subject.send(:parse_key, :status, :playlist, '0')).to eql(0) }
+
+      context "for :listplaylists command" do
+        it { expect(subject.send(:parse_key, :listplaylists, :playlist, '0')).to eql('0') }
+        it { expect(subject.send(:parse_key, :listplaylists, :playlist, '70s')).to eql('70s') }
+      end
     end
 
     context "with :db_update key" do


### PR DESCRIPTION
# Example

```ruby
require "ruby-mpd"

mpd = MPD.new
mpd.connect

begin
  playlist = MPD::Playlist.new(mpd, "70s")
  playlist.add("http://us1.internet-radio.com:8180/listen.pls")
  mpd.playlists.first.destroy
ensure
  mpd.disconnect
end
```

# Error

```
/home/jan/.rvm/gems/ruby-2.3.0/gems/ruby-mpd-0.3.3/lib/ruby-mpd.rb:274:in `handle_server_response': [rm] No such playlist (MPD::NotFound)
        from /home/jan/.rvm/gems/ruby-2.3.0/gems/ruby-mpd-0.3.3/lib/ruby-mpd.rb:196:in `block in send_command'
        from /home/jan/.rvm/gems/ruby-2.3.0/gems/ruby-mpd-0.3.3/lib/ruby-mpd.rb:191:in `synchronize'
        from /home/jan/.rvm/gems/ruby-2.3.0/gems/ruby-mpd-0.3.3/lib/ruby-mpd.rb:191:in `send_command'
        from /home/jan/.rvm/gems/ruby-2.3.0/gems/ruby-mpd-0.3.3/lib/ruby-mpd/playlist.rb:96:in `destroy'
        from mpd.rb:9:in `<main>'
```

# Problem

It seems like the `playlist` key has two different meanings.

1. playlist id
2. playlist name

The problem is handled in the code, but only the case if a playlist name starts with a character, not if the playlist name starts with a number. If a string starts with a number and you call `#to_i` on it, ruby will only use the leading numbers and transforms them to an integer value.

```ruby
require "pp"
require "ruby-mpd"

mpd = MPD.new
mpd.connect

begin
  playlist = MPD::Playlist.new(mpd, "70s")
  playlist.add("http://us1.internet-radio.com:8180/listen.pls")
  pp mpd.playlists.map(&:name)
ensure
  mpd.disconnect
end
```

__Expected Output__

```
["70s"]
```

__Actual Output__

```
["70"]
```